### PR TITLE
Fix broken resource links and add validation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # chayden
+
+This repository hosts static pages for Chris Hayden.
+
+## Tests
+
+To check for missing resources referenced in the HTML files, run:
+
+```
+./tests/check_resources.sh
+```

--- a/css/print.css
+++ b/css/print.css
@@ -1,0 +1,5 @@
+/* Minimal print styles */
+body {
+  background: none;
+  color: #000;
+}

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
   <title>Home Page</title>
   <meta name="author" content="" />
 
-  <!-- CodeRay syntax highlighting CSS -->
-  <link rel="stylesheet" href="/css/coderay.css" type="text/css" />
    
   <!-- Homepage CSS -->
   <link rel="stylesheet" href="css/screen.css" type="text/css" media="screen, projection" />

--- a/research.html
+++ b/research.html
@@ -8,8 +8,6 @@
   <title>Research</title>
   <meta name="author" content="" />
 
-  <!-- CodeRay syntax highlighting CSS -->
-  <link rel="stylesheet" href="/css/coderay.css" type="text/css" />
    
   <!-- Homepage CSS -->
   <link rel="stylesheet" href="css/screen.css" type="text/css" media="screen, projection" />

--- a/tests/check_resources.sh
+++ b/tests/check_resources.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Verify that resources referenced in HTML files exist.
+set -e
+status=0
+for html in *.html; do
+  echo "Checking $html"
+  refs=$(grep -oE '(href|src)="[^"]+"' "$html" | sed -E 's/(href|src)="([^"]+)"/\2/')
+  for res in $refs; do
+    case "$res" in
+      http:*|https:*|//*)
+        continue ;;
+    esac
+    path=${res#"/"}
+    path=${path%%\?*}
+    if [ ! -e "$path" ]; then
+      echo "Missing resource: $res (referenced in $html)"
+      status=1
+    fi
+  done
+done
+exit $status


### PR DESCRIPTION
## Summary
- append missing newline to README and document tests
- remove obsolete coderay css links
- add minimal print stylesheet
- add script to verify resources referenced in HTML

## Testing
- `./tests/check_resources.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840ba4d029c8321b617e2ab645c9a37